### PR TITLE
feat: add location monitoring service bootstrap

### DIFF
--- a/WasuremonoZero.xcodeproj/project.pbxproj
+++ b/WasuremonoZero.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		A1B2C3D41E00000100000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41E00000100000005 /* ContentView.swift */; };
 		A1B2C3D41E00000100000003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41E00000100000006 /* Assets.xcassets */; };
 		A1B2C3D41E00000100000008 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41E00000100000009 /* NotificationService.swift */; };
+		A1B2C3D41E0000010000000A /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41E0000010000000B /* LocationService.swift */; };
 /* UI Tests build file */
 		A1B2C3D41E00000200000001 /* UIScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41E00000200000004 /* UIScreenshotTests.swift */; };
 /* End PBXBuildFile section */
@@ -22,6 +23,7 @@
 		A1B2C3D41E00000100000006 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A1B2C3D41E00000100000007 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A1B2C3D41E00000100000009 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		A1B2C3D41E0000010000000B /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 /* UI Tests product and sources */
 		A1B2C3D41E00000200000010 /* WasuremonoZeroUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WasuremonoZeroUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B2C3D41E00000200000004 /* UIScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScreenshotTests.swift; sourceTree = "<group>"; };
@@ -61,6 +63,7 @@
 				A1B2C3D41E00000100000004 /* WasuremonoZeroApp.swift */,
 				A1B2C3D41E00000100000005 /* ContentView.swift */,
 				A1B2C3D41E00000100000009 /* NotificationService.swift */,
+				A1B2C3D41E0000010000000B /* LocationService.swift */,
 				A1B2C3D41E00000100000006 /* Assets.xcassets */,
 				A1B2C3D41E00000100000007 /* Info.plist */,
 			);
@@ -189,6 +192,7 @@
 				A1B2C3D41E00000100000001 /* WasuremonoZeroApp.swift in Sources */,
 				A1B2C3D41E00000100000002 /* ContentView.swift in Sources */,
 				A1B2C3D41E00000100000008 /* NotificationService.swift in Sources */,
+				A1B2C3D41E0000010000000A /* LocationService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WasuremonoZero/LocationService.swift
+++ b/WasuremonoZero/LocationService.swift
@@ -1,0 +1,73 @@
+import CoreLocation
+import Foundation
+
+protocol CLLocationManaging: AnyObject {
+    var delegate: CLLocationManagerDelegate? { get set }
+    var authorizationStatus: CLAuthorizationStatus { get }
+
+    func requestWhenInUseAuthorization()
+    func requestAlwaysAuthorization()
+    func startMonitoringSignificantLocationChanges()
+    func startMonitoringVisits()
+    func stopMonitoringSignificantLocationChanges()
+    func stopMonitoringVisits()
+}
+
+extension CLLocationManager: CLLocationManaging {}
+
+protocol LocationServiceDelegate: AnyObject {
+    func locationService(_ service: LocationService, didUpdateLocations locations: [CLLocation])
+    func locationService(_ service: LocationService, didVisit visit: CLVisit)
+    func locationService(_ service: LocationService, didChangeAuthorization status: CLAuthorizationStatus)
+}
+
+final class LocationService: NSObject {
+    weak var delegate: LocationServiceDelegate?
+
+    private let locationManager: CLLocationManaging
+
+    init(locationManager: CLLocationManaging = CLLocationManager()) {
+        self.locationManager = locationManager
+        super.init()
+        self.locationManager.delegate = self
+    }
+
+    var authorizationStatus: CLAuthorizationStatus {
+        locationManager.authorizationStatus
+    }
+
+    func requestPermissions() {
+        switch authorizationStatus {
+        case .notDetermined:
+            locationManager.requestWhenInUseAuthorization()
+        case .authorizedWhenInUse:
+            locationManager.requestAlwaysAuthorization()
+        default:
+            break
+        }
+    }
+
+    func startMonitoring() {
+        locationManager.startMonitoringSignificantLocationChanges()
+        locationManager.startMonitoringVisits()
+    }
+
+    func stopMonitoring() {
+        locationManager.stopMonitoringSignificantLocationChanges()
+        locationManager.stopMonitoringVisits()
+    }
+}
+
+extension LocationService: CLLocationManagerDelegate {
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        delegate?.locationService(self, didChangeAuthorization: manager.authorizationStatus)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        delegate?.locationService(self, didUpdateLocations: locations)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didVisit visit: CLVisit) {
+        delegate?.locationService(self, didVisit: visit)
+    }
+}

--- a/WasuremonoZero/WasuremonoZeroApp.swift
+++ b/WasuremonoZero/WasuremonoZeroApp.swift
@@ -1,23 +1,34 @@
 import CoreLocation
 import SwiftUI
+import UIKit
 
 @main
 struct WasuremonoZeroApp: App {
-    @StateObject private var appCoordinator = AppCoordinator()
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .task {
-                    appCoordinator.start()
-                }
         }
     }
 }
 
-final class AppCoordinator: NSObject, ObservableObject {
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    private let appCoordinator = AppCoordinator()
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        appCoordinator.start()
+        return true
+    }
+}
+
+final class AppCoordinator: NSObject {
     private let notificationService: NotificationService
     private let locationService: LocationService
+    private var hasStarted = false
 
     override init() {
         let notificationService = NotificationService()
@@ -31,6 +42,11 @@ final class AppCoordinator: NSObject, ObservableObject {
     }
 
     func start() {
+        guard hasStarted == false else {
+            return
+        }
+
+        hasStarted = true
         notificationService.configureCategories()
         locationService.requestPermissions()
         startLocationMonitoringIfAuthorized()

--- a/WasuremonoZero/WasuremonoZeroApp.swift
+++ b/WasuremonoZero/WasuremonoZeroApp.swift
@@ -1,15 +1,60 @@
+import CoreLocation
 import SwiftUI
 
 @main
 struct WasuremonoZeroApp: App {
-    private let notificationService = NotificationService()
+    @StateObject private var appCoordinator = AppCoordinator()
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .task {
-                    notificationService.configureCategories()
+                    appCoordinator.start()
                 }
+        }
+    }
+}
+
+final class AppCoordinator: NSObject, ObservableObject {
+    private let notificationService: NotificationService
+    private let locationService: LocationService
+
+    override init() {
+        let notificationService = NotificationService()
+        let locationService = LocationService()
+
+        self.notificationService = notificationService
+        self.locationService = locationService
+
+        super.init()
+        self.locationService.delegate = self
+    }
+
+    func start() {
+        notificationService.configureCategories()
+        locationService.requestPermissions()
+        startLocationMonitoringIfAuthorized()
+    }
+
+    private func startLocationMonitoringIfAuthorized() {
+        switch locationService.authorizationStatus {
+        case .authorizedAlways, .authorizedWhenInUse:
+            locationService.startMonitoring()
+        default:
+            break
+        }
+    }
+}
+
+extension AppCoordinator: LocationServiceDelegate {
+    func locationService(_ service: LocationService, didUpdateLocations locations: [CLLocation]) {}
+
+    func locationService(_ service: LocationService, didVisit visit: CLVisit) {}
+
+    func locationService(_ service: LocationService, didChangeAuthorization status: CLAuthorizationStatus) {
+        startLocationMonitoringIfAuthorized()
+        if status == .authorizedWhenInUse {
+            locationService.requestPermissions()
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a testable location monitoring layer and centralize app startup so the app can request location permissions and start Significant Location Change / Visit monitoring for background-triggered notifications.

### Description
- Add `LocationService` as a `CLLocationManager` wrapper with a `CLLocationManaging` protocol to allow dependency injection and testing, exposing permission flow and start/stop methods and delegate callbacks (`LocationServiceDelegate`).
- Add an `AppCoordinator` in `WasuremonoZeroApp` that configures notification categories, requests location permissions, and starts monitoring when authorization permits. 
- Update the Xcode project to include `LocationService.swift` in the app target sources.

### Testing
- Attempted to run `xcodebuild -scheme WasuremonoZero -destination 'generic/platform=iOS' -configuration Debug build`, but `xcodebuild` is not available in this environment so the build could not be executed.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bee501500832fbd2251e2d70f7b50)